### PR TITLE
Update vexriscv_sim.cfg

### DIFF
--- a/tcl/target/vexriscv_sim.cfg
+++ b/tcl/target/vexriscv_sim.cfg
@@ -20,6 +20,7 @@ jtag newtap $_CHIPNAME bridge -expected-id $_CPUTAPID -irlen 4 -ircapture 0x1 -i
 target create $_CHIPNAME.cpu0 vexriscv -endian $_ENDIAN -chain-position $_CHIPNAME.bridge -coreid 0 -dbgbase 0xF00F0000
 vexriscv readWaitCycles 12
 vexriscv cpuConfigFile $VEXRISCV_YAML
+vexriscv networkProtocol iverilog
 
 
 poll_period 50


### PR DESCRIPTION
In the most recent commit, `vexriscv->useTCP` defaults to 0. This would prevent `target/vexriscv.c` from connecting verilator target, break [VexRiscv verilator demo](https://github.com/SpinalHDL/VexRiscv#interactive-debug-of-the-simulated-cpu-via-gdb-openocd-and-verilator). Invoking `vexriscv networkProtocol` fixes it.