### PR TITLE
Don't soft reset CPU during first CPU examine.

### DIFF
--- a/src/target/vexriscv.c
+++ b/src/target/vexriscv.c
@@ -1745,10 +1745,6 @@ static int vexriscv_examine(struct target *target)
 	if (!target_was_examined(target)) {
 
 		target_set_examined(target);
-		//Soft reset
-		vexriscv_assert_reset(target);
-		vexriscv_deassert_reset(target);
-
 
 		uint32_t halted;
 		int retval = vexriscv_is_halted(target,&halted);


### PR DESCRIPTION
In the existing code, a CPU soft reset is issued when you first connect OpenOCD to the CPU, and there's no way to avoid it. 

This is undesirable behavior because it prevents somebody from connecting OpenOCD to a running system without losing the current state of the CPU.

If the user really wants a reset of the CPU, they can always issues a reset themselves with an extra OpenOCD command.

Tom
