### PR TITLE
src: flash: nor: vexriscv: Change helper include

### DIFF
--- a/src/flash/nor/vexriscv_nor_spi.c
+++ b/src/flash/nor/vexriscv_nor_spi.c
@@ -34,7 +34,7 @@
 #include <helper/binarybuffer.h>
 #include <target/algorithm.h>
 #include <target/target.h>
-#include "command.h"
+#include <helper/command.h>
 #include <math.h>
 
 typedef struct  {


### PR DESCRIPTION
Use system header command.h from helper include directory instead of
directory include.

Signed-off-by: Daniel Schultz <d.schultz@phytec.de>



This fixs a build conflict after merging upstream Openocd.